### PR TITLE
cmake: make doxygen and clang-format optional

### DIFF
--- a/cmake/code-style.cmake
+++ b/cmake/code-style.cmake
@@ -1,7 +1,8 @@
 # Find clang-format
 find_program(CLANG_FORMAT "clang-format")
 if(NOT CLANG_FORMAT)
-    message(FATAL_ERROR "clang-format not found")
+    message(STATUS "clang-format not found (No style related targets)")
+    return()
 else()
     message(STATUS "Found clang-format: ${CLANG_FORMAT}")
 endif()

--- a/cmake/generate-docs.cmake
+++ b/cmake/generate-docs.cmake
@@ -1,12 +1,12 @@
 # Look for Doxygen package
 find_package(Doxygen)
-if(DOXYGEN_FOUND)
-    add_custom_target(docs
-        COMMAND ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/docs/config.doxy
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/docs
-        COMMENT "Generating API documentation with Doxygen"
-        VERBATIM
-    )
-else(DOXYGEN_FOUND)
-    message(STATUS "Doxygen needs to be installed to generate the doxygen documentation")
-endif(DOXYGEN_FOUND)
+if(NOT DOXYGEN_FOUND)
+    return()
+endif(NOT DOXYGEN_FOUND)
+
+add_custom_target(docs
+    COMMAND ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/docs/config.doxy
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/docs
+    COMMENT "Generating API documentation with Doxygen"
+    VERBATIM
+)


### PR DESCRIPTION
This commit makes doxygen and clang-format dependencies optional. If the dependencies are missing, the targets related to them are not generated.